### PR TITLE
feat: use a switch control for interception enablement

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -365,6 +365,68 @@ h3 {
   min-width: 140px;
 }
 
+.switch-field {
+  min-width: 140px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.88rem;
+  color: var(--muted);
+}
+
+.toggle-switch {
+  position: relative;
+  width: 54px;
+  height: 30px;
+  display: inline-flex;
+}
+
+.toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-slider {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  transition: background 180ms ease, border-color 180ms ease;
+}
+
+.toggle-slider::before {
+  content: "";
+  position: absolute;
+  width: 22px;
+  height: 22px;
+  left: 3px;
+  top: 3px;
+  border-radius: 50%;
+  background: var(--muted);
+  transition: transform 180ms ease, background 180ms ease;
+}
+
+.toggle-switch input:checked + .toggle-slider {
+  background: var(--brand);
+  border-color: var(--brand);
+}
+
+.toggle-switch input:checked + .toggle-slider::before {
+  transform: translateX(24px);
+  background: #ffffff;
+}
+
+.toggle-switch input:focus-visible + .toggle-slider {
+  outline: 2px solid var(--info);
+  outline-offset: 2px;
+}
+
+.toggle-switch input:disabled + .toggle-slider {
+  opacity: 0.6;
+}
+
 .interception-controls input,
 .interception-controls select {
   min-width: 150px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1517,17 +1517,20 @@ function App() {
         <div className="interception-header">
           <h2>{texts.interceptionTitle}</h2>
           <div className="interception-controls">
-            <label>
-              {texts.interceptionEnabled}
-              <select
-                value={interception?.enabled ? "on" : "off"}
-                disabled={busy || interceptBusy}
-                onChange={(event) => handleApplyInterceptionConfig(event.target.value === "on")}
-              >
-                <option value="off">OFF</option>
-                <option value="on">ON</option>
-              </select>
-            </label>
+            <div className="switch-field">
+              <span>{texts.interceptionEnabled}</span>
+              <label className="toggle-switch">
+                <input
+                  type="checkbox"
+                  role="switch"
+                  checked={Boolean(interception?.enabled)}
+                  disabled={busy || interceptBusy}
+                  onChange={(event) => handleApplyInterceptionConfig(event.target.checked)}
+                  aria-label={texts.interceptionEnabled}
+                />
+                <span className="toggle-slider" aria-hidden="true" />
+              </label>
+            </div>
             <label>
               {texts.interceptionTimeout}
               <input


### PR DESCRIPTION
## Resumen
- reemplaza el selector ON/OFF de interceptación por un switch accesible (`input[type=checkbox]` con `role=switch`)
- mantiene la lógica existente de activación/desactivación (`handleApplyInterceptionConfig`)
- agrega estilos de toggle consistentes con tema light/dark

## Verificación
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml

Closes #31
