### PR TITLE
feat: move interception timeout into rules modal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -537,6 +537,11 @@ h3 {
   gap: 10px;
 }
 
+.modal-timeout-field {
+  margin-top: 10px;
+  max-width: 240px;
+}
+
 .modal-actions {
   justify-content: flex-end;
   margin-top: 12px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1583,20 +1583,6 @@ function App() {
                 <span className="toggle-slider" aria-hidden="true" />
               </label>
             </div>
-            <label>
-              {texts.interceptionTimeout}
-              <input
-                value={interceptTimeoutInput}
-                onChange={(event) => setInterceptTimeoutInput(event.target.value.replace(/[^\d]/g, ""))}
-                disabled={busy || interceptBusy}
-              />
-            </label>
-            <button
-              disabled={busy || interceptBusy}
-              onClick={() => handleApplyInterceptionConfig(Boolean(interception?.enabled))}
-            >
-              {texts.applyInterception}
-            </button>
             <button disabled={busy || interceptBusy} onClick={() => setRulesModalOpen(true)}>
               {texts.manageRules}
             </button>
@@ -1979,6 +1965,14 @@ function App() {
                 {texts.close}
               </button>
             </div>
+            <label className="modal-timeout-field">
+              {texts.interceptionTimeout}
+              <input
+                value={interceptTimeoutInput}
+                onChange={(event) => setInterceptTimeoutInput(event.target.value.replace(/[^\d]/g, ""))}
+                disabled={busy || interceptBusy}
+              />
+            </label>
             {interceptRulesInput.length === 0 && <p className="muted">{texts.interceptionRulesEmptyHint}</p>}
             {interceptRulesInput.length > 0 && (
               <div className="interception-rules">


### PR DESCRIPTION
## Resumen
- mueve el control de timeout al modal/tab `Rules`
- elimina controles duplicados de timeout fuera de Rules
- mantiene un único punto de aplicación de cambios (Rules + timeout) con `Apply`

## Verificación
- nvm use && npm run build
- cargo check --manifest-path src-tauri/Cargo.toml

Closes #36
