### PR TITLE
feat: automate CA installation via ADB with verified fallback

### DIFF
--- a/src-tauri/src/tracer/adb.rs
+++ b/src-tauri/src/tracer/adb.rs
@@ -186,6 +186,38 @@ pub fn launch_certificate_installer(serial: &str, remote_path: &str) -> Result<(
     Ok(())
 }
 
+pub fn adb_root(serial: &str) -> Result<String, String> {
+    run_adb(&["-s", serial, "root"])
+}
+
+pub fn adb_remount(serial: &str) -> Result<String, String> {
+    run_adb(&["-s", serial, "remount"])
+}
+
+pub fn chmod_remote_file(serial: &str, remote_path: &str, mode: &str) -> Result<(), String> {
+    run_adb(&["-s", serial, "shell", "chmod", mode, remote_path])?;
+    Ok(())
+}
+
+pub fn chown_remote_file(serial: &str, remote_path: &str, owner: &str) -> Result<(), String> {
+    run_adb(&["-s", serial, "shell", "chown", owner, remote_path])?;
+    Ok(())
+}
+
+pub fn remote_file_exists(serial: &str, remote_path: &str) -> Result<bool, String> {
+    match run_adb(&["-s", serial, "shell", "ls", remote_path]) {
+        Ok(_) => Ok(true),
+        Err(err)
+            if err.contains("No such file")
+                || err.contains("not found")
+                || err.contains("No such") =>
+        {
+            Ok(false)
+        }
+        Err(err) => Err(err),
+    }
+}
+
 fn list_emulators(adb_binary: &str) -> Result<(Vec<EmulatorDevice>, usize), String> {
     let devices = list_devices(adb_binary)?;
     let mut online_emulators = Vec::new();

--- a/src-tauri/src/tracer/adb_controller.rs
+++ b/src-tauri/src/tracer/adb_controller.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 pub use super::adb::{
-    clear_emulator_proxy, ensure_adb_available, ensure_emulator_online, get_adb_status,
-    launch_certificate_installer, push_file_to_emulator, set_emulator_proxy, AdbStatus,
-    EmulatorDevice,
+    adb_remount, adb_root, chmod_remote_file, chown_remote_file, clear_emulator_proxy,
+    ensure_adb_available, ensure_emulator_online, get_adb_status, launch_certificate_installer,
+    push_file_to_emulator, remote_file_exists, set_emulator_proxy, AdbStatus, EmulatorDevice,
 };

--- a/src-tauri/src/tracer/cert.rs
+++ b/src-tauri/src/tracer/cert.rs
@@ -27,6 +27,8 @@ pub struct CertificateSetupResult {
     pub cert_local_path: String,
     pub cert_emulator_path: String,
     pub installer_launched: bool,
+    pub installation_status: String,
+    pub verification_note: String,
     pub instructions: String,
 }
 
@@ -59,21 +61,101 @@ pub fn prepare_certificate_install(
 
     adb::push_file_to_emulator(emulator_serial, paths.cert_der.as_path(), remote_path)?;
 
-    let launch_result = adb::launch_certificate_installer(emulator_serial, remote_path);
-    let installer_launched = launch_result.is_ok();
+    match try_install_certificate_with_adb_root(emulator_serial, paths) {
+        Ok(system_path) => Ok(CertificateSetupResult {
+            cert_local_path: local_cert,
+            cert_emulator_path: system_path.clone(),
+            installer_launched: false,
+            installation_status: "installed".to_string(),
+            verification_note: format!("Certificado verificado en {system_path}."),
+            instructions: "Certificado instalado automaticamente en el store de sistema del emulador via ADB. Reinicia las apps del emulador si no toman el nuevo trust store de inmediato.".to_string(),
+        }),
+        Err(automation_err) => {
+            let launch_result = adb::launch_certificate_installer(emulator_serial, remote_path);
+            if launch_result.is_ok() {
+                return Ok(CertificateSetupResult {
+                    cert_local_path: local_cert,
+                    cert_emulator_path: remote_path.to_string(),
+                    installer_launched: true,
+                    installation_status: "pendingUserAction".to_string(),
+                    verification_note: format!(
+                        "Instalacion automatica no disponible: {automation_err}"
+                    ),
+                    instructions: "Certificado copiado al emulador y pantalla de instalacion abierta. Completa la instalacion en Android (nombre sugerido: HTTP Request Tracer CA).".to_string(),
+                });
+            }
 
-    let instructions = if installer_launched {
-        "Certificado copiado al emulador. Completa la instalacion desde la pantalla abierta (nombre sugerido: HTTP Request Tracer CA).".to_string()
-    } else {
-        "Certificado copiado al emulador. Abre Settings > Security > Encryption & credentials > Install a certificate > CA certificate y selecciona http-request-tracer-ca.cer en Downloads.".to_string()
-    };
+            Ok(CertificateSetupResult {
+                cert_local_path: local_cert,
+                cert_emulator_path: remote_path.to_string(),
+                installer_launched: false,
+                installation_status: "failed".to_string(),
+                verification_note: format!(
+                    "Fallo instalacion automatica: {automation_err}. No fue posible abrir instalador de Android."
+                ),
+                instructions: "No se pudo completar la instalacion de certificado via ADB. Verifica que el emulador permita `adb root`/`adb remount` o instala manualmente desde Settings > Security > Encryption & credentials > Install a certificate > CA certificate.".to_string(),
+            })
+        }
+    }
+}
 
-    Ok(CertificateSetupResult {
-        cert_local_path: local_cert,
-        cert_emulator_path: remote_path.to_string(),
-        installer_launched,
-        instructions,
-    })
+fn try_install_certificate_with_adb_root(
+    emulator_serial: &str,
+    paths: &CaBundlePaths,
+) -> Result<String, String> {
+    let cert_hash = certificate_subject_hash_old(paths.cert_pem.as_path())?;
+    let hashed_name = format!("{cert_hash}.0");
+    let hashed_local_path = std::env::temp_dir().join(&hashed_name);
+    let hashed_remote_path = format!("/system/etc/security/cacerts/{hashed_name}");
+
+    fs::copy(&paths.cert_pem, &hashed_local_path)
+        .map_err(|err| format!("Failed to prepare hashed certificate file: {err}"))?;
+
+    let install_result = (|| -> Result<String, String> {
+        adb::adb_root(emulator_serial)
+            .map_err(|err| format!("adb root failed (emulator might not support root): {err}"))?;
+        adb::adb_remount(emulator_serial)
+            .map_err(|err| format!("adb remount failed (system partition not writable): {err}"))?;
+        adb::push_file_to_emulator(emulator_serial, hashed_local_path.as_path(), &hashed_remote_path)
+            .map_err(|err| format!("Failed to push CA into system trust store: {err}"))?;
+        adb::chown_remote_file(emulator_serial, &hashed_remote_path, "root:root")
+            .map_err(|err| format!("Failed to set CA owner: {err}"))?;
+        adb::chmod_remote_file(emulator_serial, &hashed_remote_path, "644")
+            .map_err(|err| format!("Failed to set CA permissions: {err}"))?;
+
+        let exists = adb::remote_file_exists(emulator_serial, &hashed_remote_path)
+            .map_err(|err| format!("Failed to verify installed CA file: {err}"))?;
+        if !exists {
+            return Err("CA file was not found in system trust store after install.".to_string());
+        }
+
+        Ok(hashed_remote_path.clone())
+    })();
+
+    let _ = fs::remove_file(&hashed_local_path);
+    install_result
+}
+
+fn certificate_subject_hash_old(cert_pem: &Path) -> Result<String, String> {
+    let output = run_command_capture(
+        "openssl",
+        &[
+            "x509",
+            "-inform",
+            "PEM",
+            "-subject_hash_old",
+            "-in",
+            &path_as_str(cert_pem)?,
+            "-noout",
+        ],
+    )?;
+
+    let hash = output.lines().next().unwrap_or_default().trim();
+    if hash.is_empty() {
+        return Err("Unable to resolve certificate hash for Android trust store.".to_string());
+    }
+
+    Ok(hash.to_string())
 }
 
 fn generate_ca_bundle(cert_pem: &Path, cert_der: &Path, key_pem: &Path) -> Result<(), String> {
@@ -120,13 +202,18 @@ fn generate_ca_bundle(cert_pem: &Path, cert_der: &Path, key_pem: &Path) -> Resul
 }
 
 fn run_command(bin: &str, args: &[&str]) -> Result<(), String> {
+    let _ = run_command_capture(bin, args)?;
+    Ok(())
+}
+
+fn run_command_capture(bin: &str, args: &[&str]) -> Result<String, String> {
     let output = Command::new(bin)
         .args(args)
         .output()
         .map_err(|_| format!("Failed to execute {bin}. Ensure it is installed."))?;
 
     if output.status.success() {
-        return Ok(());
+        return Ok(String::from_utf8_lossy(&output.stdout).to_string());
     }
 
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,8 @@ type CertificateSetupResult = {
   certLocalPath: string;
   certEmulatorPath: string;
   installerLaunched: boolean;
+  installationStatus: "installed" | "pendingUserAction" | "failed";
+  verificationNote: string;
   instructions: string;
 };
 
@@ -589,6 +591,12 @@ function toUserError(error: unknown): string {
   }
   if (raw.includes("cannot connect to daemon")) {
     return `${raw} Sugerencia: ejecuta \`adb start-server\` y luego Refresh.`;
+  }
+  if (raw.includes("adb root failed")) {
+    return `${raw} Sugerencia: usa un AVD debug/userdebug (no Play image) o completa la instalacion manual desde Settings.`;
+  }
+  if (raw.includes("adb remount failed")) {
+    return `${raw} Sugerencia: el emulador no permite montar /system en escritura; usa instalacion manual o un AVD con root.`;
   }
 
   return raw;
@@ -1127,9 +1135,18 @@ function App() {
         emulatorSerial: selectedEmulator,
       });
       setCertInfoText(
-        `${result.instructions} Archivo local: ${result.certLocalPath}. Archivo en emulador: ${result.certEmulatorPath}.`,
+        `${result.instructions} Verificacion: ${result.verificationNote} Archivo local: ${result.certLocalPath}. Archivo en emulador: ${result.certEmulatorPath}.`,
       );
-      updatePreferences({ certTrusted: false });
+      if (result.installationStatus === "installed") {
+        setInfoText("Certificado instalado automaticamente via ADB.");
+        updatePreferences({ certTrusted: true });
+      } else if (result.installationStatus === "pendingUserAction") {
+        setInfoText("Certificado copiado. Completa la confirmacion en el emulador.");
+        updatePreferences({ certTrusted: false });
+      } else {
+        setInfoText("No fue posible completar la instalacion automatica del certificado.");
+        updatePreferences({ certTrusted: false });
+      }
       await loadSessionAndAdb();
     } catch (error) {
       setErrorText(toUserError(error));


### PR DESCRIPTION
## Resumen
- agrega instalacion automatica de CA en emulador via ADB root/remount + push a `/system/etc/security/cacerts`
- valida instalacion verificando presencia del cert en trust store del sistema
- mantiene fallback guiado (abrir instalador Android) cuando el emulador no permite root/remount
- mejora feedback en UI con estado final (`installed`, `pendingUserAction`, `failed`) y nota de verificacion
- incorpora mensajes accionables para errores de `adb root` y `adb remount`

## Verificación
- cargo check --manifest-path src-tauri/Cargo.toml
- nvm use && npm run build

Closes #35
