### PR TITLE
chore: harden repo governance and security policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+# Default ownership
+* @DerSarco
+
+# Security and release-critical paths
+/.github/CODEOWNERS @DerSarco
+/.github/workflows/* @DerSarco
+/.github/release-notes-template.md @DerSarco
+/SECURITY.md @DerSarco
+/CONTRIBUTING.md @DerSarco
+/LICENSE @DerSarco
+/THIRD_PARTY_NOTICES.md @DerSarco
+
+# Runtime and tracing core
+/src-tauri/src/lib.rs @DerSarco
+/src-tauri/src/tracer/* @DerSarco
+/src-tauri/Cargo.toml @DerSarco
+/src-tauri/Cargo.lock @DerSarco
+/src-tauri/tauri.conf.json @DerSarco
+
+# Dependency and packaging definitions
+/package.json @DerSarco
+/package-lock.json @DerSarco

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug report
+description: Report a reproducible defect
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please provide enough detail to reproduce it quickly.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened and what did you expect?
+      placeholder: A concise description of the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Include exact steps and data when possible.
+      placeholder: |
+        1. Open app
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Provide host and emulator details.
+      placeholder: |
+        App version:
+        macOS version:
+        CPU architecture (arm64/x64):
+        Node version:
+        ADB version:
+        Emulator/device:
+    validations:
+      required: true
+  - type: dropdown
+    id: security_impact
+    attributes:
+      label: Security impact
+      description: Does this bug expose sensitive data or allow unsafe behavior?
+      options:
+        - Unknown
+        - No
+        - Yes
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste sanitized logs or screenshots. Do not include secrets/tokens.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability report (private)
+    url: https://github.com/DerSarco/httprequesttracer_matecode/security/advisories/new
+    about: Please report security vulnerabilities privately using GitHub Security Advisories.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Suggest a new capability or improvement
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Keep proposals specific and scoped.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What pain point are you solving?
+      placeholder: Describe the current limitation.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the expected behavior and UX.
+      placeholder: Explain how this should work.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What alternatives did you evaluate?
+      placeholder: Optional alternatives.
+  - type: dropdown
+    id: risk
+    attributes:
+      label: Risk level
+      description: Estimate implementation risk for security/stability.
+      options:
+        - Low
+        - Medium
+        - High
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+## Summary
+
+Describe the change in one or two clear paragraphs.
+
+## Scope
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor
+- [ ] Docs
+- [ ] CI/Release
+- [ ] Security hardening
+
+## Validation
+
+- [ ] `npm run build` passed locally
+- [ ] `npm test` passed locally (or N/A explained below)
+- [ ] Manual smoke test performed (if UI/runtime affected)
+
+Validation notes:
+
+## Security Checklist
+
+- [ ] No secrets, tokens, keys, or credentials added
+- [ ] No unsafe shell execution path introduced
+- [ ] No new telemetry/network exfiltration path introduced
+- [ ] Sensitive headers/cookies/auth values remain masked or controlled
+- [ ] Workflow permissions follow least privilege
+
+## Release Impact
+
+- [ ] No release impact
+- [ ] Affects release workflow
+- [ ] Requires version bump
+- [ ] Requires migration or manual maintainer steps
+
+Release notes (if needed):

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "security"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "security"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "ci"
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - "**"
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (JavaScript/TypeScript)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/release-from-branch.yml
+++ b/.github/workflows/release-from-branch.yml
@@ -12,7 +12,7 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: release-${{ github.ref_name }}-${{ github.event.inputs.version || 'auto' }}
@@ -22,6 +22,8 @@ jobs:
   prepare:
     name: Resolve version and prepare release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
@@ -137,6 +139,8 @@ jobs:
   build_macos:
     name: Build macOS bundle (${{ matrix.target }})
     needs: prepare
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing
+
+Thanks for contributing to HTTP Request Tracer.
+
+## Ground Rules
+
+- Keep changes focused and scoped.
+- Use feature branches; do not commit directly to `master`.
+- Open PRs with clear validation notes.
+- Follow least privilege and local-first security constraints.
+
+## Development Setup
+
+```bash
+npm install
+npm run tauri dev
+```
+
+Prerequisites:
+
+- macOS
+- Node.js `20.19+` or `22.12+`
+- Rust toolchain
+- `adb` in `PATH`
+
+## Branching
+
+- Feature/fix branches: `codex/<short-description>`
+- Release branches: `release/vX.Y.Z`
+
+## Before Opening a PR
+
+Run:
+
+```bash
+npm run build
+npm test
+```
+
+If tests are intentionally skipped, explain why in the PR.
+
+## PR Requirements
+
+- Use the PR template.
+- Keep commits meaningful and atomic.
+- Include screenshots for UI changes.
+- Mention release impact when relevant.
+
+## Security Requirements for Code Changes
+
+- Do not add secrets, credentials, or tokens to code/logs.
+- Do not introduce arbitrary shell execution from UI input.
+- Keep ADB command usage constrained to explicit allowlisted flows.
+- Preserve cleanup behavior for emulator proxy changes.
+- Preserve masking/redaction behavior for sensitive values.
+
+## Dependency and License Hygiene
+
+- Keep dependencies up to date.
+- Ensure new dependencies are compatible with project license posture.
+- Update `THIRD_PARTY_NOTICES.md` when direct dependencies change.
+
+## Reporting Security Issues
+
+Use the private process in `SECURITY.md`, not public issues.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ This project depends on third-party open source packages under their own license
 
 - Full notices: `THIRD_PARTY_NOTICES.md`
 
+## Contributing and security
+
+- Contribution guidelines: `CONTRIBUTING.md`
+- Vulnerability reporting policy: `SECURITY.md`
+- Maintainer hardening checklist: `docs/repo-hardening-checklist.md`
+
 ## Documentation
 
 - `docs/mvp-01-configuracion-preferencias.md`
@@ -95,6 +101,7 @@ This project depends on third-party open source packages under their own license
 - `docs/mvp-08-testing-strategy.md`
 - `docs/mvp-09-packaging-guide.md`
 - `docs/mvp-15-guardrails-interceptacion.md`
+- `docs/repo-hardening-checklist.md`
 - `docs/spike-05-tls-pinning-trust-model.md`
 - `docs/spike-06-performance-baseline.md`
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| --- | --- |
+| `0.1.x` | Yes |
+| `< 0.1.0` | No |
+
+## Reporting a Vulnerability
+
+Please do not open public issues for security vulnerabilities.
+
+Use a private report through GitHub Security Advisories:
+
+- https://github.com/DerSarco/httprequesttracer_matecode/security/advisories/new
+
+Include:
+
+- Affected version/tag
+- Reproduction steps
+- Impact assessment
+- Suggested mitigation (if known)
+
+## Response Targets
+
+- Initial acknowledgment: within 72 hours
+- Triage and severity assessment: within 7 days
+- Patch/release timeline: based on severity and exploitability
+
+## Disclosure Policy
+
+- We coordinate fixes privately first.
+- We publish details after a fix is available or mitigation is documented.
+- Credit is given to reporters unless anonymity is requested.
+
+## Security Boundaries and Expectations
+
+- This app is local-first and should not exfiltrate captured traffic.
+- Host OS proxy must not be modified by tracing workflows.
+- Emulator proxy changes must be reversible (`:0` cleanup).
+- Sensitive data in headers/cookies should be masked or handled carefully.

--- a/docs/repo-hardening-checklist.md
+++ b/docs/repo-hardening-checklist.md
@@ -1,0 +1,43 @@
+# Repo Hardening Checklist
+
+This checklist contains GitHub repository settings that are not stored in source files.
+
+## Branch Protection (`master`)
+
+- Require a pull request before merging.
+- Require at least 1 approval.
+- Dismiss stale approvals when new commits are pushed.
+- Require conversation resolution before merging.
+- Require status checks to pass before merging.
+- Required check: `Frontend tests (Vitest)`.
+- Restrict who can push to `master` (maintainers only).
+- Disable force pushes.
+- Disable branch deletion.
+
+## Pull Request Safety
+
+- Require linear history or squash merge policy (team preference).
+- Enable auto-delete head branches after merge.
+- Enforce CODEOWNERS review for protected paths.
+
+## GitHub Actions Security
+
+- Set default `GITHUB_TOKEN` permissions to read-only at repo level.
+- Allow only trusted actions and reusable workflows.
+- Restrict workflow creation/modification to maintainers.
+
+## Supply Chain Security
+
+- Enable Dependabot alerts.
+- Enable Dependabot security updates.
+- Enable secret scanning.
+- Enable push protection for secrets.
+- Enable code scanning (CodeQL) for default branch.
+
+## Release Governance
+
+- Publish releases only from `release/vX.Y.Z` branches.
+- Keep version synchronized in `package.json`.
+- Keep version synchronized in `src-tauri/Cargo.toml`.
+- Keep version synchronized in `src-tauri/tauri.conf.json`.
+- Verify release assets for both macOS architectures before publish.


### PR DESCRIPTION
## Summary
- add repository governance and security docs (SECURITY.md, CONTRIBUTING.md)
- add maintainer controls (CODEOWNERS, PR template, issue templates)
- add dependency/security automation (dependabot, CodeQL workflow)
- tighten workflow token permissions in CI and release pipelines
- document non-versioned hardening settings for GitHub repo admins

## Validation
- npm run build
- npm test
