### PR TITLE
docs: add macOS quarantine workaround disclaimer

### DIFF
--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -14,10 +14,17 @@
 1. Download the zip that matches your Mac architecture.
 2. Unzip and move `HTTP Request Tracer.app` to `Applications`.
 3. Open the app and allow execution in macOS Security settings if prompted.
+4. If macOS shows "damaged and can't be opened", run:
+
+```bash
+xattr -dr com.apple.quarantine "/Applications/HTTP Request Tracer.app"
+open "/Applications/HTTP Request Tracer.app"
+```
 
 ## Known limitations
 - Certificate install in Android emulator still requires user interaction.
 - Project is in MVP stage; report edge cases in Issues.
+- App is not yet notarized for macOS distribution.
 
 ## Validation checklist
 - App starts and detects ADB + emulator.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ Bundle output:
 - Detailed guide: `docs/release-macos-playbook.md`
 - Packaging notes: `docs/mvp-09-packaging-guide.md`
 
+## First launch on macOS (quarantine workaround)
+
+Until app signing + notarization is enabled, macOS may block the downloaded app with a
+"damaged and can't be opened" message.
+
+If that happens, run:
+
+```bash
+xattr -dr com.apple.quarantine "/Applications/HTTP Request Tracer.app"
+open "/Applications/HTTP Request Tracer.app"
+```
+
 ## Security and trust notes
 
 - HTTPS capture requires trusting the generated local CA in the emulator.

--- a/docs/release-macos-playbook.md
+++ b/docs/release-macos-playbook.md
@@ -41,9 +41,12 @@ git push -u origin release/v0.1.0
    - `Start Tracing` captura requests.
    - `Stop Tracing` revierte proxy (`:0`).
    - `Cmd + Q` muestra confirmacion y guia de cleanup.
+   - Validar workaround de cuarentena si aplica:
+     - `xattr -dr com.apple.quarantine "/Applications/HTTP Request Tracer.app"`
 
 5. Publicar release:
    - Revisar notas en draft (plantilla en `.github/release-notes-template.md`).
+   - Incluir disclaimer de cuarentena mientras no exista notarizacion.
    - Completar `Known limitations` reales de la version.
    - Presionar `Publish release` en GitHub.
 


### PR DESCRIPTION
## Summary
- add first-launch quarantine workaround to README
- include same workaround in release notes template
- document quarantine disclaimer step in macOS release playbook

## Validation
- npm run build