### PR TITLE
feat: close remaining MVP milestone issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  frontend-tests:
     name: Frontend tests (Vitest)
     runs-on: ubuntu-latest
 
@@ -33,3 +33,17 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+  backend-tests:
+    name: Backend tests (Cargo)
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run cargo tests
+        run: cargo test --manifest-path src-tauri/Cargo.toml

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ HTTP Request Tracer aims to provide a practical, free, local desktop alternative
 
 - Clean request explorer with details for headers, params, cookies, and bodies.
 - Start/stop tracing directly from the app by managing emulator proxy settings over ADB.
-- HTTPS support through local CA generation + guided certificate install flow.
+- HTTPS support through a Matecode-branded local CA + guided certificate install flow.
 - Interception mode with pending queue, edit, forward, and drop actions.
 - Sort and filter captured requests for high-volume sessions.
 - ES/EN language support, theme settings, and basic privacy masking.
@@ -78,6 +78,7 @@ open "/Applications/HTTP Request Tracer.app"
 ## Security and trust notes
 
 - HTTPS capture requires trusting the generated local CA in the emulator.
+- The generated CA is shown as `Matecode HTTP Tracer Local CA`; that visible name does not mean Android already trusts it.
 - Apps with TLS pinning can still block interception.
 - Optional ADB override: set `ADB_PATH` to force a specific binary.
 - Common ADB fallback paths:

--- a/docs/mvp-08-testing-strategy.md
+++ b/docs/mvp-08-testing-strategy.md
@@ -2,16 +2,27 @@
 
 ## Cobertura automatizada base
 
-1. Frontend (`src/App.test.tsx`)
+1. Frontend (`src/App.test.tsx`, `src/App.additional.test.tsx`)
 - Helpers de formato y normalizacion de errores.
 - Flujo Start/Stop basico.
 - Render de detalle request/response.
 - Filtros combinables + limpiar filtros.
 - Limpieza de sesion (`Clear Session`).
+- Smoke UI adicional para configuracion de interceptacion, export cURL, install flow y salida controlada.
 
-2. Backend (`src-tauri/src/tracer/mitm.rs`)
+2. Shared modules
+- `src/shared/utils/requestHelpers.test.ts`: parsing/canonizacion de headers, params, cookies, filtros, masking y export cURL.
+- `src/shared/api/tauriClient.test.ts`: contratos de comandos Tauri.
+- `src/shared/preferences.test.ts`: defaults/persistencia robusta.
+- `src/shared/utils/clipboard.test.ts`: clipboard nativo y fallback.
+
+3. Backend (`src-tauri/src/tracer/mitm.rs`, `src-tauri/src/tracer/cert.rs`)
 - Comportamiento de buffer circular de captura.
 - Limpieza de store en memoria.
+- Clamp de timeout y normalizacion de reglas de interceptacion.
+- Timeout/fallback de requests interceptadas y limite de cola pendiente.
+- Truncado seguro de payload editable + fallback para body binario/encoding invalido.
+- Identidad visible del certificado Matecode y path de instalacion consistente.
 
 ## Smoke test manual recomendado
 
@@ -35,9 +46,8 @@
 
 ## CI/local
 
-- CI: `.github/workflows/ci.yml` ejecuta checks de frontend.
+- CI: `.github/workflows/ci.yml` ejecuta `npm test` y `cargo test`.
 - Local recomendado:
 - `npm test -- --run`
 - `cargo test`
 - `npm run tauri build`
-

--- a/docs/mvp-15-guardrails-interceptacion.md
+++ b/docs/mvp-15-guardrails-interceptacion.md
@@ -23,6 +23,16 @@
 - Sesion en memoria (buffer circular), sin envio a backend externo.
 - `Clear Session` elimina capturas activas en UI/backend.
 
+## Cobertura automatizada relevante
+
+- Frontend:
+- masking de headers/cookies y export cURL sin secretos por defecto.
+- smoke de configuracion de reglas, edicion y reenvio de request interceptada.
+- Backend:
+- timeout/fallback de interceptacion sin bloqueo indefinido.
+- limite de cola pendiente para sesiones largas.
+- truncado seguro de payload editable y fallback de preview para binario/encoding invalido.
+
 ## Riesgos conocidos
 
 - TLS pinning estricto puede impedir MITM aun con CA confiada.
@@ -33,4 +43,3 @@
 - Usar interceptacion solo en entornos QA/debug.
 - Mantener `showSensitiveData` en modo oculto salvo necesidad puntual.
 - Configurar timeout conservador (10s-20s) para evitar friccion.
-

--- a/docs/spike-05-tls-pinning-trust-model.md
+++ b/docs/spike-05-tls-pinning-trust-model.md
@@ -4,7 +4,7 @@ Fecha: 2026-02-19
 
 ## Resumen
 
-El tracer usa MITM local con una CA propia (`HTTP Request Tracer Local CA`).
+El tracer usa MITM local con una CA propia (`Matecode HTTP Tracer Local CA`).
 Para inspeccion HTTPS, el cliente Android debe confiar esa CA.
 
 ## Casos soportados
@@ -31,6 +31,7 @@ Para inspeccion HTTPS, el cliente Android debe confiar esa CA.
 
 - Mostrar mensaje claro:
   - "HTTPS requiere instalar y confiar la CA local en el emulador."
+  - "La identidad visible del certificado es Matecode; eso no reemplaza el paso de trust."
   - "Apps con TLS pinning pueden no ser interceptables."
 - Agregar checklist guiado en onboarding:
   1. Preparar e instalar CA.

--- a/src-tauri/src/tracer/cert.rs
+++ b/src-tauri/src/tracer/cert.rs
@@ -10,9 +10,12 @@ use super::adb;
 
 const APP_DIR_NAME: &str = ".http-request-tracer";
 const CA_DIR_NAME: &str = "ca";
-const CA_CERT_PEM_FILE: &str = "http-request-tracer-ca.pem";
-const CA_CERT_DER_FILE: &str = "http-request-tracer-ca.cer";
-const CA_KEY_FILE: &str = "http-request-tracer-ca.key";
+const CA_CERT_PEM_FILE: &str = "matecode-http-tracer-ca.pem";
+const CA_CERT_DER_FILE: &str = "matecode-http-tracer-ca.cer";
+const CA_KEY_FILE: &str = "matecode-http-tracer-ca.key";
+const CA_DISPLAY_NAME: &str = "Matecode HTTP Tracer Local CA";
+const CA_ORGANIZATION: &str = "Matecode";
+const CA_ORGANIZATIONAL_UNIT: &str = "Developer Tools";
 
 #[derive(Debug, Clone)]
 pub struct CaBundlePaths {
@@ -56,22 +59,29 @@ pub fn prepare_certificate_install(
     emulator_serial: &str,
     paths: &CaBundlePaths,
 ) -> Result<CertificateSetupResult, String> {
-    let remote_path = "/sdcard/Download/http-request-tracer-ca.cer";
+    let remote_path = emulator_cert_remote_path();
     let local_cert = paths.cert_der.to_string_lossy().to_string();
 
-    adb::push_file_to_emulator(emulator_serial, paths.cert_der.as_path(), remote_path)?;
+    adb::push_file_to_emulator(emulator_serial, paths.cert_der.as_path(), &remote_path)?;
     let open_security_result = adb::open_security_settings(emulator_serial);
     let (installer_launched, verification_note, instructions) = match open_security_result {
         Ok(_) => (
             true,
-            "Se abrio Install a certificate / Encryption & credentials en el emulador."
-                .to_string(),
-            "Certificado copiado al emulador. Completa la instalacion en Android y selecciona el archivo desde Download si corresponde.".to_string(),
+            format!(
+                "Se abrio Install a certificate / Encryption & credentials en el emulador. La CA visible sera '{CA_DISPLAY_NAME}'."
+            ),
+            format!(
+                "Certificado '{CA_DISPLAY_NAME}' copiado al emulador. Completa la instalacion en Android y selecciona el archivo desde Download si corresponde. Ver que Android muestre ese nombre no implica confianza hasta terminar la instalacion."
+            ),
         ),
         Err(err) => (
             false,
-            format!("No se pudo abrir Install a certificate automaticamente: {err}"),
-            "Certificado copiado al emulador. Abre manualmente Settings > Security > Encryption & credentials > Install a certificate > CA certificate y selecciona el archivo en Download.".to_string(),
+            format!(
+                "No se pudo abrir Install a certificate automaticamente: {err}. La CA a instalar aparecera como '{CA_DISPLAY_NAME}'."
+            ),
+            format!(
+                "Certificado '{CA_DISPLAY_NAME}' copiado al emulador. Abre manualmente Settings > Security > Encryption & credentials > Install a certificate > CA certificate y selecciona el archivo en Download. Ese nombre identifica el certificado, pero la confianza HTTPS solo queda habilitada cuando Android termina la instalacion."
+            ),
         ),
     };
 
@@ -98,7 +108,7 @@ fn generate_ca_bundle(cert_pem: &Path, cert_der: &Path, key_pem: &Path) -> Resul
             "-days",
             "3650",
             "-subj",
-            "/CN=HTTP Request Tracer Local CA/O=HTTP Request Tracer",
+            &ca_subject(),
             "-addext",
             "basicConstraints=critical,CA:TRUE",
             "-addext",
@@ -126,6 +136,16 @@ fn generate_ca_bundle(cert_pem: &Path, cert_der: &Path, key_pem: &Path) -> Resul
     )?;
 
     Ok(())
+}
+
+fn emulator_cert_remote_path() -> String {
+    format!("/sdcard/Download/{CA_CERT_DER_FILE}")
+}
+
+fn ca_subject() -> String {
+    format!(
+        "/CN={CA_DISPLAY_NAME}/O={CA_ORGANIZATION}/OU={CA_ORGANIZATIONAL_UNIT}"
+    )
 }
 
 fn run_command(bin: &str, args: &[&str]) -> Result<(), String> {
@@ -159,4 +179,22 @@ fn path_as_str(path: &Path) -> Result<String, String> {
     path.to_str()
         .map(ToOwned::to_owned)
         .ok_or("Invalid non-UTF8 path".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ca_subject, emulator_cert_remote_path};
+
+    #[test]
+    fn matecode_identity_is_reflected_in_subject_and_install_path() {
+        let subject = ca_subject();
+
+        assert!(subject.contains("/CN=Matecode HTTP Tracer Local CA"));
+        assert!(subject.contains("/O=Matecode"));
+        assert!(subject.contains("/OU=Developer Tools"));
+        assert_eq!(
+            emulator_cert_remote_path(),
+            "/sdcard/Download/matecode-http-tracer-ca.cer"
+        );
+    }
 }

--- a/src-tauri/src/tracer/mitm.rs
+++ b/src-tauri/src/tracer/mitm.rs
@@ -870,7 +870,18 @@ fn now_unix_ms() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{CaptureStore, CapturedExchange};
+    use std::time::Duration;
+
+    use tokio::sync::oneshot;
+
+    use super::{
+        apply_intercept_patch, render_body_preview, Body, CaptureHandler, CaptureStore,
+        CapturedExchange, HeaderEntry, InterceptAction, InterceptDecisionInput,
+        InterceptionConfigInput, InterceptionController, InterceptionRule,
+        InterceptWaitResult, PendingInterceptRequest, Request, SharedCaptureStore,
+        SharedInterceptionController, DEFAULT_MAX_PENDING_INTERCEPTS,
+        MAX_EDITABLE_BODY_BYTES, MAX_INTERCEPT_TIMEOUT_MS, MIN_INTERCEPT_TIMEOUT_MS,
+    };
 
     #[test]
     fn capture_store_behaves_as_circular_buffer() {
@@ -894,6 +905,159 @@ mod tests {
         assert!(store.snapshot().is_empty());
     }
 
+    #[test]
+    fn interception_config_clamps_timeout_and_normalizes_rules() {
+        let mut controller = InterceptionController::default();
+        let snapshot = controller.apply_config(InterceptionConfigInput {
+            enabled: true,
+            timeout_ms: Some(MAX_INTERCEPT_TIMEOUT_MS + 10_000),
+            rules: Some(vec![
+                InterceptionRule {
+                    id: "rule-1".to_string(),
+                    enabled: true,
+                    host_contains: " Api.Example.com ".to_string(),
+                    path_contains: " /Login ".to_string(),
+                    method: " post ".to_string(),
+                },
+                InterceptionRule {
+                    id: "   ".to_string(),
+                    enabled: true,
+                    host_contains: "ignored".to_string(),
+                    path_contains: String::new(),
+                    method: String::new(),
+                },
+            ]),
+        });
+
+        assert!(snapshot.enabled);
+        assert_eq!(snapshot.timeout_ms, MAX_INTERCEPT_TIMEOUT_MS);
+        assert_eq!(snapshot.rules.len(), 1);
+        assert_eq!(snapshot.rules[0].host_contains, "api.example.com");
+        assert_eq!(snapshot.rules[0].path_contains, "/login");
+        assert_eq!(snapshot.rules[0].method, "POST");
+    }
+
+    #[test]
+    fn apply_decision_delivers_drop_and_clears_pending() {
+        let mut controller = InterceptionController::default();
+        let (tx, mut rx) = oneshot::channel();
+        controller.register_pending(sample_pending_request(7), tx);
+
+        controller
+            .apply_decision(InterceptDecisionInput {
+                request_id: 7,
+                action: "drop".to_string(),
+                method: None,
+                url: None,
+                headers: None,
+                body: None,
+                query: None,
+                cookies: None,
+            })
+            .expect("drop decision should be accepted");
+
+        let decision = rx.try_recv().expect("decision should be delivered");
+        assert!(matches!(decision.action, InterceptAction::Drop));
+        assert_eq!(controller.snapshot().pending_count, 0);
+    }
+
+    #[test]
+    fn register_pending_evicts_oldest_entries_when_queue_reaches_limit() {
+        let mut controller = InterceptionController::default();
+
+        for id in 1..=(DEFAULT_MAX_PENDING_INTERCEPTS as u64 + 1) {
+            let (tx, _rx) = oneshot::channel();
+            controller.register_pending(sample_pending_request(id), tx);
+        }
+
+        let snapshot = controller.snapshot();
+        assert_eq!(snapshot.pending_count, DEFAULT_MAX_PENDING_INTERCEPTS);
+        assert_eq!(snapshot.pending_requests.first().map(|request| request.id), Some(2));
+        assert_eq!(
+            snapshot.pending_requests.last().map(|request| request.id),
+            Some(DEFAULT_MAX_PENDING_INTERCEPTS as u64 + 1)
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_intercept_decision_times_out_and_cleans_pending() {
+        let mut controller = InterceptionController::default();
+        controller.enabled = true;
+        controller.timeout_ms = MIN_INTERCEPT_TIMEOUT_MS.min(5);
+
+        let controller: SharedInterceptionController =
+            std::sync::Arc::new(tokio::sync::Mutex::new(controller));
+        let store: SharedCaptureStore =
+            std::sync::Arc::new(std::sync::Mutex::new(CaptureStore::default()));
+        let handler = CaptureHandler::new(store, controller.clone());
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(100),
+            handler.wait_intercept_decision(
+                "POST",
+                "api.example.com",
+                "/login",
+                sample_pending_request(9),
+            ),
+        )
+        .await
+        .expect("interception wait should complete");
+
+        assert!(matches!(result, InterceptWaitResult::Timeout));
+
+        let snapshot = controller.lock().await.snapshot();
+        assert_eq!(snapshot.pending_count, 0);
+    }
+
+    #[test]
+    fn apply_intercept_patch_updates_request_parts_and_truncates_large_body() {
+        let request = Request::builder()
+            .method("POST")
+            .uri("https://example.com/login?before=1")
+            .body(Body::empty())
+            .expect("request should build");
+        let (mut parts, _) = request.into_parts();
+        let mut body_bytes = Vec::new();
+
+        apply_intercept_patch(
+            &mut parts,
+            &mut body_bytes,
+            super::InterceptPatch {
+                method: Some("PATCH".to_string()),
+                url: Some("https://example.com/session".to_string()),
+                headers: Some(vec![HeaderEntry {
+                    name: "x-test".to_string(),
+                    value: "one".to_string(),
+                }]),
+                body: Some("x".repeat(MAX_EDITABLE_BODY_BYTES + 128)),
+                query: Some("via=editor".to_string()),
+                cookies: Some("session=updated".to_string()),
+            },
+        );
+
+        assert_eq!(parts.method.as_str(), "PATCH");
+        assert_eq!(parts.uri.to_string(), "https://example.com/session?via=editor");
+        assert_eq!(body_bytes.len(), MAX_EDITABLE_BODY_BYTES);
+        assert_eq!(parts.headers.get("x-test").unwrap(), "one");
+        assert_eq!(parts.headers.get("cookie").unwrap(), "session=updated");
+        assert_eq!(
+            parts.headers.get("content-length").unwrap(),
+            MAX_EDITABLE_BODY_BYTES.to_string().as_str()
+        );
+    }
+
+    #[test]
+    fn render_body_preview_uses_safe_fallbacks_for_binary_and_invalid_encoded_payloads() {
+        let binary_preview = render_body_preview(&[0_u8, 159, 146, 150], Some("application/octet-stream"), None)
+            .expect("binary preview should return fallback text");
+        assert!(binary_preview.contains("Payload no textual"));
+
+        let invalid_gzip_preview = render_body_preview(&[1_u8, 2, 3, 4], Some("text/plain"), Some("gzip"))
+            .expect("invalid gzip preview should return fallback text");
+        assert!(invalid_gzip_preview.contains("content-encoding 'gzip'"));
+        assert!(invalid_gzip_preview.contains("no fue posible decodificarlo"));
+    }
+
     fn sample_exchange(id: u64) -> CapturedExchange {
         CapturedExchange {
             id,
@@ -914,6 +1078,25 @@ mod tests {
             intercept_status: None,
             original_method: None,
             original_url: None,
+        }
+    }
+
+    fn sample_pending_request(id: u64) -> PendingInterceptRequest {
+        PendingInterceptRequest {
+            id,
+            started_at_unix_ms: 0,
+            method: "POST".to_string(),
+            url: "https://api.example.com/login".to_string(),
+            host: "api.example.com".to_string(),
+            path: "/login".to_string(),
+            headers: vec![HeaderEntry {
+                name: "content-type".to_string(),
+                value: "application/json".to_string(),
+            }],
+            body: Some("{\"ok\":true}".to_string()),
+            body_size: 11,
+            status: "pending".to_string(),
+            last_error: None,
         }
     }
 }

--- a/src/App.additional.test.tsx
+++ b/src/App.additional.test.tsx
@@ -1,0 +1,370 @@
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import App from "./App";
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type InvokeMock = typeof invoke & { mockImplementation: (fn: (cmd: string, payload?: unknown) => Promise<unknown>) => void };
+
+let exitRequestedHandler: (() => void | Promise<void>) | null = null;
+let closeRequestedHandler:
+  | ((event: { preventDefault: () => void }) => void | Promise<void>)
+  | null = null;
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async (_event: string, handler: () => void | Promise<void>) => {
+    exitRequestedHandler = handler;
+    return vi.fn();
+  }),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: vi.fn(() => ({
+    onCloseRequested: vi.fn(async (handler: (event: { preventDefault: () => void }) => void | Promise<void>) => {
+      closeRequestedHandler = handler;
+      return vi.fn();
+    }),
+  })),
+}));
+
+const adbStatus = {
+  adbAvailable: true,
+  adbPath: "/usr/bin/adb",
+  adbVersion: "1.0.41",
+  emulators: [{ serial: "emulator-5554" }],
+  message: null,
+};
+
+const sessionInactive = {
+  active: false,
+  emulatorSerial: null,
+  proxyAddress: null,
+  startedAtUnixMs: null,
+  caCertificatePath: null,
+  lastError: null,
+};
+
+let currentCapturedRequests: Array<{
+  id: number;
+  startedAtUnixMs: number;
+  durationMs: number;
+  method: string;
+  url: string;
+  host: string;
+  path: string;
+  statusCode: number;
+  requestHeaders: Array<{ name: string; value: string }>;
+  responseHeaders: Array<{ name: string; value: string }>;
+  requestBody: string | null;
+  responseBody: string | null;
+  requestBodySize: number;
+  responseBodySize: number;
+  intercepted?: boolean;
+  interceptStatus?: string | null;
+  originalMethod?: string | null;
+  originalUrl?: string | null;
+}> = [];
+
+let currentInterception = {
+  enabled: false,
+  timeoutMs: 12000,
+  rules: [] as Array<{ id: string; enabled: boolean; hostContains: string; pathContains: string; method: string }>,
+  pendingCount: 0,
+  pendingRequests: [] as Array<{
+    id: number;
+    startedAtUnixMs: number;
+    method: string;
+    url: string;
+    host: string;
+    path: string;
+    headers: Array<{ name: string; value: string }>;
+    body: string | null;
+    bodySize: number;
+    status: string;
+    lastError: string | null;
+  }>,
+};
+
+let prepareCertificateResult = {
+  certLocalPath: "/tmp/matecode-http-tracer-ca.cer",
+  certEmulatorPath: "/sdcard/Download/matecode-http-tracer-ca.cer",
+  installerLaunched: true,
+  installationStatus: "pendingUserAction" as const,
+  verificationNote: "Open Android Security to complete trust",
+  instructions: "Certificate copied",
+};
+
+let lastConfiguredPayload: unknown = null;
+let lastDecisionPayload: unknown = null;
+let confirmExitCalls = 0;
+
+const invokeMock = invoke as InvokeMock;
+
+beforeEach(() => {
+  localStorage.clear();
+  localStorage.setItem(
+    "http-request-tracer.preferences.v1",
+    JSON.stringify({
+      language: "en",
+      theme: "light",
+      fontScale: "medium",
+      showSensitiveData: false,
+      certTrusted: true,
+    }),
+  );
+
+  exitRequestedHandler = null;
+  closeRequestedHandler = null;
+  lastConfiguredPayload = null;
+  lastDecisionPayload = null;
+  confirmExitCalls = 0;
+
+  currentCapturedRequests = [];
+  currentInterception = {
+    enabled: false,
+    timeoutMs: 12000,
+    rules: [],
+    pendingCount: 0,
+    pendingRequests: [],
+  };
+
+  prepareCertificateResult = {
+    certLocalPath: "/tmp/matecode-http-tracer-ca.cer",
+    certEmulatorPath: "/sdcard/Download/matecode-http-tracer-ca.cer",
+    installerLaunched: true,
+    installationStatus: "pendingUserAction",
+    verificationNote: "Open Android Security to complete trust",
+    instructions: "Certificate copied",
+  };
+
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: {
+      writeText: vi.fn().mockResolvedValue(undefined),
+    },
+  });
+
+  invokeMock.mockImplementation(async (cmd: string, payload?: unknown) => {
+    switch (cmd) {
+      case "get_adb_status":
+        return adbStatus;
+      case "get_session_state":
+        return sessionInactive;
+      case "get_captured_requests":
+        return currentCapturedRequests;
+      case "get_interception_state":
+        return currentInterception;
+      case "prepare_certificate_install":
+        return prepareCertificateResult;
+      case "configure_interception":
+        lastConfiguredPayload = payload;
+        currentInterception = {
+          enabled: Boolean((payload as { config: { enabled: boolean } }).config.enabled),
+          timeoutMs: (payload as { config: { timeoutMs: number } }).config.timeoutMs,
+          rules: (payload as { config: { rules: typeof currentInterception.rules } }).config.rules,
+          pendingCount: currentInterception.pendingCount,
+          pendingRequests: currentInterception.pendingRequests,
+        };
+        return currentInterception;
+      case "decide_intercept_request":
+        lastDecisionPayload = payload;
+        currentInterception = {
+          ...currentInterception,
+          pendingCount: 0,
+          pendingRequests: [],
+        };
+        return currentInterception;
+      case "confirm_app_exit":
+        confirmExitCalls += 1;
+        return null;
+      case "clear_captured_requests":
+        currentCapturedRequests = [];
+        return null;
+      default:
+        throw new Error(`Unhandled invoke: ${cmd}`);
+    }
+  });
+});
+
+describe("App additional coverage", () => {
+  it("updates settings and copies request data with sensitive-data handling", async () => {
+    currentCapturedRequests = [
+      {
+        id: 901,
+        startedAtUnixMs: 1700000005000,
+        durationMs: 85,
+        method: "POST",
+        url: "https://api.example.com/login",
+        host: "api.example.com",
+        path: "/login",
+        statusCode: 200,
+        requestHeaders: [
+          { name: "Authorization", value: "Bearer abcdef1234" },
+          { name: "Content-Type", value: "application/json" },
+        ],
+        responseHeaders: [{ name: "Set-Cookie", value: "session=xyz; Path=/; HttpOnly" }],
+        requestBody: "{\"ok\":true}",
+        responseBody: "{\"token\":\"123\"}",
+        requestBodySize: 11,
+        responseBodySize: 15,
+      },
+    ];
+
+    render(<App />);
+
+    expect(await screen.findByText("Estado actualizado.")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("row", { name: /api\.example\.com \/login 200 85 ms/i }));
+
+    await userEvent.click(screen.getByRole("button", { name: "Headers" }));
+    expect(screen.getByText("Bea***34")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Export as cURL" }));
+    const clipboardWrite = vi.mocked(navigator.clipboard.writeText);
+    expect(clipboardWrite).toHaveBeenCalledWith(
+      "curl -X POST 'https://api.example.com/login' -H 'Content-Type: application/json' --data-raw '{\"ok\":true}'",
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Settings" }));
+    await userEvent.selectOptions(screen.getByLabelText("Sensitive data"), "show");
+    await userEvent.click(screen.getByRole("button", { name: "Close settings" }));
+
+    expect(screen.getByText("Bearer abcdef1234")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Copy URL" }));
+    expect(clipboardWrite).toHaveBeenLastCalledWith("https://api.example.com/login");
+    expect(await screen.findByText("Copied to clipboard.")).toBeInTheDocument();
+  });
+
+  it("runs the certificate install flow and records follow-up details", async () => {
+    render(<App />);
+
+    expect(await screen.findByText("Estado actualizado.")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Prepare CA Install" }));
+
+    expect(screen.getByRole("dialog", { name: "Certificate install permissions" })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(await screen.findByText("Certificado copiado. Completa la confirmacion en el emulador.")).toBeInTheDocument();
+    expect(screen.getByText(/Certificate copied Verificacion:/)).toBeInTheDocument();
+
+    const persistedPreferences = JSON.parse(localStorage.getItem("http-request-tracer.preferences.v1") ?? "{}");
+    expect(persistedPreferences.certTrusted).toBe(false);
+  });
+
+  it("applies interception rules and forwards edited pending requests", async () => {
+    currentInterception = {
+      enabled: false,
+      timeoutMs: 12000,
+      rules: [],
+      pendingCount: 1,
+      pendingRequests: [
+        {
+          id: 321,
+          startedAtUnixMs: 1700000007000,
+          method: "POST",
+          url: "https://auth.example.com/login?next=%2Fhome",
+          host: "auth.example.com",
+          path: "/login?next=%2Fhome",
+          headers: [
+            { name: "Cookie", value: "session=abc" },
+            { name: "Content-Type", value: "application/json" },
+          ],
+          body: "{\"email\":\"a@example.com\"}",
+          bodySize: 25,
+          status: "pending",
+          lastError: null,
+        },
+      ],
+    };
+
+    render(<App />);
+
+    expect(await screen.findByText("Estado actualizado.")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /Interception/ }));
+
+    expect(screen.getByText("auth.example.com/login?next=%2Fhome")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Rules" }));
+    const rulesDialog = screen.getByRole("dialog", { name: "Rules" });
+    await userEvent.click(within(rulesDialog).getByRole("button", { name: "Add rule" }));
+    await userEvent.clear(within(rulesDialog).getByLabelText("Timeout (ms)"));
+    await userEvent.type(within(rulesDialog).getByLabelText("Timeout (ms)"), "999999");
+    await userEvent.type(within(rulesDialog).getByLabelText("Host contains"), " auth.example.com ");
+    await userEvent.type(within(rulesDialog).getByLabelText("Path contains"), " /login ");
+    await userEvent.selectOptions(within(rulesDialog).getByLabelText("Method"), "POST");
+    await userEvent.click(within(rulesDialog).getByRole("button", { name: "Apply" }));
+
+    expect(lastConfiguredPayload).toEqual({
+      config: {
+        enabled: false,
+        timeoutMs: 120000,
+        rules: [
+          {
+            id: expect.any(String),
+            enabled: true,
+            hostContains: "auth.example.com",
+            pathContains: "/login",
+            method: "POST",
+          },
+        ],
+      },
+    });
+
+    await userEvent.clear(screen.getByLabelText("Method"));
+    await userEvent.type(screen.getByLabelText("Method"), "PATCH");
+    await userEvent.clear(screen.getByLabelText("URL"));
+    await userEvent.type(screen.getByLabelText("URL"), "https://auth.example.com/session");
+    await userEvent.clear(screen.getByLabelText("Query string"));
+    await userEvent.type(screen.getByLabelText("Query string"), "via=editor");
+    await userEvent.clear(screen.getByLabelText("Cookies"));
+    await userEvent.type(screen.getByLabelText("Cookies"), "session=updated");
+    await userEvent.clear(screen.getByLabelText("Headers (one per line: Name: Value)"));
+    await userEvent.type(screen.getByLabelText("Headers (one per line: Name: Value)"), "X-Test: one\nBroken");
+    fireEvent.change(screen.getByLabelText("Body"), { target: { value: "{\"patched\":true}" } });
+    await userEvent.click(screen.getByRole("button", { name: "Forward" }));
+
+    await waitFor(() =>
+      expect(lastDecisionPayload).toEqual({
+        decision: {
+          requestId: 321,
+          action: "forward",
+          method: "PATCH",
+          url: "https://auth.example.com/session",
+          headers: [
+            { name: "X-Test", value: "one" },
+            { name: "Broken", value: "" },
+          ],
+          body: "{\"patched\":true}",
+          query: "via=editor",
+          cookies: "session=updated",
+        },
+      }),
+    );
+    expect(await screen.findByText("Request interceptada reenviada.")).toBeInTheDocument();
+  });
+
+  it("opens the exit modal from the Tauri events and confirms exit cleanup", async () => {
+    render(<App />);
+
+    expect(await screen.findByText("Estado actualizado.")).toBeInTheDocument();
+
+    await act(async () => {
+      await exitRequestedHandler?.();
+    });
+
+    expect(screen.getByRole("dialog", { name: "Before exit" })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Exit and clean" }));
+
+    await waitFor(() => {
+      expect(confirmExitCalls).toBe(1);
+    });
+
+    await act(async () => {
+      await closeRequestedHandler?.({ preventDefault: vi.fn() });
+    });
+    expect(screen.getByRole("dialog", { name: "Before exit" })).toBeInTheDocument();
+  });
+});

--- a/src/shared/api/tauriClient.test.ts
+++ b/src/shared/api/tauriClient.test.ts
@@ -1,0 +1,54 @@
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearCapturedRequests,
+  confirmAppExit,
+  configureInterception,
+  decideInterceptRequest,
+  getAdbStatus,
+  getCapturedRequests,
+  getInterceptionState,
+  getSessionState,
+  prepareCertificateInstall,
+  startTracing,
+  stopTracing,
+} from "./tauriClient";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+describe("tauriClient", () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockReset();
+    vi.mocked(invoke).mockResolvedValue(undefined);
+  });
+
+  it("calls the expected tauri commands", async () => {
+    await getAdbStatus();
+    await getSessionState();
+    await getCapturedRequests();
+    await clearCapturedRequests();
+    await getInterceptionState();
+    await configureInterception({ enabled: true, timeoutMs: 4000, rules: [] });
+    await decideInterceptRequest({ requestId: 7, action: "drop" });
+    await prepareCertificateInstall("emulator-5554");
+    await startTracing({ emulatorSerial: "emulator-5554", proxyHost: "10.0.2.2", proxyPort: 8877 });
+    await stopTracing();
+    await confirmAppExit();
+
+    expect(vi.mocked(invoke).mock.calls).toEqual([
+      ["get_adb_status"],
+      ["get_session_state"],
+      ["get_captured_requests"],
+      ["clear_captured_requests"],
+      ["get_interception_state"],
+      ["configure_interception", { config: { enabled: true, timeoutMs: 4000, rules: [] } }],
+      ["decide_intercept_request", { decision: { requestId: 7, action: "drop" } }],
+      ["prepare_certificate_install", { emulatorSerial: "emulator-5554" }],
+      ["start_tracing", { emulatorSerial: "emulator-5554", proxyHost: "10.0.2.2", proxyPort: 8877 }],
+      ["stop_tracing"],
+      ["confirm_app_exit"],
+    ]);
+  });
+});

--- a/src/shared/preferences.test.ts
+++ b/src/shared/preferences.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadPreferences, persistPreferences } from "./preferences";
+
+const STORAGE_KEY = "http-request-tracer.preferences.v1";
+
+describe("preferences", () => {
+  it("returns defaults when storage is empty or invalid", () => {
+    localStorage.removeItem(STORAGE_KEY);
+    expect(loadPreferences()).toEqual({
+      language: "es",
+      theme: "light",
+      fontScale: "medium",
+      showSensitiveData: false,
+      certTrusted: false,
+    });
+
+    localStorage.setItem(STORAGE_KEY, "{");
+    expect(loadPreferences()).toEqual({
+      language: "es",
+      theme: "light",
+      fontScale: "medium",
+      showSensitiveData: false,
+      certTrusted: false,
+    });
+  });
+
+  it("normalizes persisted values", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        language: "en",
+        theme: "dark",
+        fontScale: "large",
+        showSensitiveData: 1,
+        certTrusted: "yes",
+      }),
+    );
+
+    expect(loadPreferences()).toEqual({
+      language: "en",
+      theme: "dark",
+      fontScale: "large",
+      showSensitiveData: true,
+      certTrusted: true,
+    });
+  });
+
+  it("persists preferences and swallows storage errors", () => {
+    const next = {
+      language: "en" as const,
+      theme: "dark" as const,
+      fontScale: "small" as const,
+      showSensitiveData: true,
+      certTrusted: true,
+    };
+
+    persistPreferences(next);
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}")).toEqual(next);
+
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+    expect(() => persistPreferences(next)).not.toThrow();
+    setItemSpy.mockRestore();
+  });
+});

--- a/src/shared/utils/clipboard.test.ts
+++ b/src/shared/utils/clipboard.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { copyToClipboard } from "./clipboard";
+
+describe("clipboard", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  function installExecCommand(result: boolean) {
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: vi.fn().mockReturnValue(result),
+    });
+    return document.execCommand as unknown as ReturnType<typeof vi.fn>;
+  }
+
+  it("rejects empty content", async () => {
+    await expect(copyToClipboard("")).rejects.toThrow("Empty content");
+  });
+
+  it("uses navigator.clipboard when available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+    await copyToClipboard("hello");
+
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("falls back to execCommand and cleans up the textarea", async () => {
+    vi.stubGlobal("navigator", {});
+    const execCommandSpy = installExecCommand(true);
+
+    await copyToClipboard("fallback");
+
+    expect(execCommandSpy).toHaveBeenCalledWith("copy");
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("throws when the fallback copy command fails", async () => {
+    vi.stubGlobal("navigator", {});
+    installExecCommand(false);
+
+    await expect(copyToClipboard("fallback")).rejects.toThrow("copy command failed");
+  });
+});

--- a/src/shared/utils/requestHelpers.test.ts
+++ b/src/shared/utils/requestHelpers.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildCurlCommand,
+  createEmptyRule,
+  createRuleId,
+  formatByteSize,
+  formatHeadersAsText,
+  getHeaderValue,
+  isSensitiveHeader,
+  maskSensitiveValue,
+  matchesStatusFilter,
+  parseCookieEntries,
+  parseHeaderLines,
+  parseParamEntries,
+} from "./requestHelpers";
+
+describe("requestHelpers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("formats byte sizes across units", () => {
+    expect(formatByteSize(999)).toBe("999 B");
+    expect(formatByteSize(1024)).toBe("1.0 KB");
+    expect(formatByteSize(1024 * 1024)).toBe("1.0 MB");
+  });
+
+  it("detects and masks sensitive values", () => {
+    expect(isSensitiveHeader("Authorization")).toBe(true);
+    expect(isSensitiveHeader("Content-Type")).toBe(false);
+    expect(maskSensitiveValue("")).toBe("[redacted]");
+    expect(maskSensitiveValue("short")).toBe("[redacted]");
+    expect(maskSensitiveValue("abcdef123456")).toBe("abc***56");
+  });
+
+  it("looks up headers case-insensitively", () => {
+    expect(getHeaderValue([{ name: "Content-Type", value: "application/json" }], "content-type")).toBe(
+      "application/json",
+    );
+    expect(getHeaderValue([], "content-type")).toBeNull();
+  });
+
+  it("parses request and response cookies", () => {
+    const cookies = parseCookieEntries({
+      id: 1,
+      startedAtUnixMs: 1,
+      durationMs: 20,
+      method: "GET",
+      url: "https://example.com",
+      host: "example.com",
+      path: "/",
+      statusCode: 200,
+      requestHeaders: [{ name: "Cookie", value: "session=abc; mode=full; broken" }],
+      responseHeaders: [
+        { name: "Set-Cookie", value: "refresh=xyz; Path=/; HttpOnly" },
+        { name: "Set-Cookie", value: "flagOnly; Secure" },
+      ],
+      requestBody: null,
+      responseBody: null,
+      requestBodySize: 0,
+      responseBodySize: 0,
+    });
+
+    expect(cookies).toEqual([
+      { source: "Request", name: "session", value: "abc" },
+      { source: "Request", name: "mode", value: "full" },
+      { source: "Request", name: "broken", value: "" },
+      { source: "Response", name: "refresh", value: "xyz" },
+      { source: "Response", name: "flagOnly", value: "" },
+    ]);
+  });
+
+  it("parses params from valid and fallback URLs", () => {
+    expect(
+      parseParamEntries({
+        id: 1,
+        startedAtUnixMs: 1,
+        durationMs: 20,
+        method: "GET",
+        url: "https://example.com/path?foo=bar&baz=qux",
+        host: "example.com",
+        path: "/path?foo=bar&baz=qux",
+        statusCode: 200,
+        requestHeaders: [],
+        responseHeaders: [],
+        requestBody: null,
+        responseBody: null,
+        requestBodySize: 0,
+        responseBodySize: 0,
+      }),
+    ).toEqual([
+      { name: "foo", value: "bar" },
+      { name: "baz", value: "qux" },
+    ]);
+
+    expect(
+      parseParamEntries({
+        id: 2,
+        startedAtUnixMs: 1,
+        durationMs: 20,
+        method: "GET",
+        url: "not a url",
+        host: "example.com",
+        path: "/path?fallback=true",
+        statusCode: 200,
+        requestHeaders: [],
+        responseHeaders: [],
+        requestBody: null,
+        responseBody: null,
+        requestBodySize: 0,
+        responseBodySize: 0,
+      }),
+    ).toEqual([{ name: "fallback", value: "true" }]);
+  });
+
+  it("matches status filters for prefixes, exact codes, ranges, and classes", () => {
+    expect(matchesStatusFilter(204, "")).toBe(true);
+    expect(matchesStatusFilter(204, "2")).toBe(true);
+    expect(matchesStatusFilter(204, "204")).toBe(true);
+    expect(matchesStatusFilter(404, "499-400")).toBe(true);
+    expect(matchesStatusFilter(503, "5xx")).toBe(true);
+    expect(matchesStatusFilter(503, "invalid")).toBe(true);
+    expect(matchesStatusFilter(204, "404")).toBe(false);
+  });
+
+  it("formats headers as text and parses them back", () => {
+    const headers = [
+      { name: "Authorization", value: "Bearer abcdef123456" },
+      { name: "Content-Type", value: "application/json" },
+    ];
+
+    expect(formatHeadersAsText(headers, false)).toBe("Authorization: Bea***56\nContent-Type: application/json");
+    expect(formatHeadersAsText(headers, true)).toBe("Authorization: Bearer abcdef123456\nContent-Type: application/json");
+    expect(parseHeaderLines("Content-Type: application/json\nX-Test: 1\nInvalidLine")).toEqual([
+      { name: "Content-Type", value: "application/json" },
+      { name: "X-Test", value: "1" },
+      { name: "InvalidLine", value: "" },
+    ]);
+  });
+
+  it("creates rules with stable defaults and falls back when crypto is unavailable", () => {
+    vi.stubGlobal("crypto", { randomUUID: () => "uuid-123" });
+    expect(createRuleId()).toBe("uuid-123");
+    expect(createEmptyRule()).toEqual({
+      id: "uuid-123",
+      enabled: true,
+      hostContains: "",
+      pathContains: "",
+      method: "",
+    });
+
+    vi.stubGlobal("crypto", undefined);
+    vi.spyOn(Date, "now").mockReturnValue(1700000000000);
+    vi.spyOn(Math, "random").mockReturnValue(0.1234);
+    expect(createRuleId()).toBe("rule-1700000000000-1234");
+  });
+
+  it("builds curl commands and omits sensitive headers when requested", () => {
+    const request = {
+      id: 1,
+      startedAtUnixMs: 1,
+      durationMs: 20,
+      method: "post",
+      url: "https://example.com/path",
+      host: "example.com",
+      path: "/path",
+      statusCode: 200,
+      requestHeaders: [
+        { name: "Authorization", value: "Bearer abcdef123456" },
+        { name: "Content-Type", value: "application/json" },
+      ],
+      responseHeaders: [],
+      requestBody: "{\"ok\":true}",
+      responseBody: null,
+      requestBodySize: 11,
+      responseBodySize: 0,
+    };
+
+    expect(buildCurlCommand(request, false)).toBe(
+      "curl -X POST 'https://example.com/path' -H 'Content-Type: application/json' --data-raw '{\"ok\":true}'",
+    );
+    expect(buildCurlCommand(request, true)).toContain("-H 'Authorization: Bearer abcdef123456'");
+  });
+});


### PR DESCRIPTION
Closes #14
Closes #20
Closes #59

## Summary
- expand frontend/shared/backend automated coverage for the MVP core flows
- run Cargo tests in CI alongside Vitest
- rebrand the generated local CA to Matecode and clarify trust messaging
