### PR TITLE
test: stabilize interception workflow coverage

### DIFF
--- a/src/App.additional.test.tsx
+++ b/src/App.additional.test.tsx
@@ -409,7 +409,7 @@ describe("App additional coverage", () => {
       }),
     );
     expect(await screen.findByText("Intercepted request forwarded.")).toBeInTheDocument();
-  });
+  }, 10_000);
 
   it("opens the exit modal from the Tauri events and confirms exit cleanup", async () => {
     render(<App />);


### PR DESCRIPTION
## Summary
- allow the interaction-heavy interception workflow test enough time to complete reliably
- preserve the existing end-to-end assertions for rules and forwarded request edits

## Verification
- `npm run test:coverage` (32 tests passed; 86.58% statements, 87.85% lines)
- `cargo test` (9 tests passed)